### PR TITLE
[bundle] Make TraceableProducer service public

### DIFF
--- a/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
+++ b/pkg/enqueue-bundle/DependencyInjection/EnqueueExtension.php
@@ -109,6 +109,7 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
             if ($config['client']['traceable_producer']) {
                 $container->register(TraceableProducer::class, TraceableProducer::class)
                     ->setDecoratedService(Producer::class)
+                    ->setPublic(true)
                     ->addArgument(new Reference(sprintf('%s.inner', TraceableProducer::class)))
                 ;
             }


### PR DESCRIPTION
So it can be used with Symfony ^4